### PR TITLE
Fix noise playing after wake even if noise is turned off in settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -132,7 +132,9 @@ class thread_with_exception(threading.Thread):
                             print('say:', data['whisper'])
                             sound.speak(data['whisper'])
                             time.sleep(int(globals.SETTING['setting']['delay']))
-                            noise.play()
+                            onOff = globals.SETTING['setting']['noise']
+                            if onOff:
+                                noise.play()
 
         finally:
             print('ended')


### PR DESCRIPTION
After the Alias was woken up and the noise-delay expired, it always started playing the noise again regardless of the "noise" setting. This fixes that bug by checking the setting first and only playing the noise if it's turned on.